### PR TITLE
fixed url prop extraction

### DIFF
--- a/src/app/components/header/header.js
+++ b/src/app/components/header/header.js
@@ -53,4 +53,4 @@ const Header = (props) => {
   );
 };
 
-export default connect(state => { return {url: state.router.pathname}; })(Header);
+export default connect(state => { return {url: state.router.location.pathname}; })(Header);


### PR DESCRIPTION
state.router doesn't have pathname property. That works ok on the client but makes SSR generate 500 server error cause location is not properly set on SSR.