### PR TITLE
Add linebreak-style rule based on process.platform for windows/unix

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "extends": "./node_modules/@pawjs/pawjs/.eslintrc",
   "settings": {
     "import/resolver": {
@@ -6,5 +6,8 @@
         "config": "./node_modules/@pawjs/pawjs/src/webpack/inc/webpack-resolver-config.js"
       }
     }
+  },
+  "rules": {
+    "linebreak-style": ["error", process.platform === "win32" ? "windows" : "unix"]
   }
-}
+};


### PR DESCRIPTION
If we are in **unix** type OS and then switch to **windows**, the editor will show the **linebreak-style** errors & vice-versa. Because of this, we have to change the rule manually. But with this solution, we won't need to change it manually as it will depend on OS type.